### PR TITLE
First cut at dynamic title in session window

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -35,7 +35,7 @@ class AppWindow(QMainWindow):
 
         self.dwarf = Dwarf(self)
 
-        self.setWindowTitle("Dwarf")
+        self.update_title()
 
         self.setCentralWidget(self.app)
         self.app.setup_ui()
@@ -66,6 +66,9 @@ class AppWindow(QMainWindow):
     def on_script_loaded(self):
         self.menu.on_script_loaded()
         self.app.on_script_loaded()
+
+    def update_title(self, title_str="Dwarf"):
+        self.setWindowTitle(title_str)
 
 
 class App(QWidget):

--- a/ui/ui_welcome.py
+++ b/ui/ui_welcome.py
@@ -321,7 +321,13 @@ class WelcomeUi(QSplitter):
         accept, what = editor.show()
         if accept:
             self.startup_script = what
-            self.app.get_dwarf().attach(widget_android_package.get_pid(), script=what)
+            app_name = widget_android_package.appname
+            app_pid = widget_android_package.get_pid()
+            if "\t" in app_name:
+                app_name = app_name.split("\t")[1]
+
+            self.app.get_dwarf().attach(app_pid, script=what)
+            self.app.get_dwarf().app_window.update_title("Dwarf - Attached to %s (pid %s)" % (app_name, app_pid))
 
     def on_spawn_picked(self, widget_android_package):
         editor = JsEditorDialog(self.app, def_text=self.startup_script,
@@ -329,4 +335,9 @@ class WelcomeUi(QSplitter):
         accept, what = editor.show()
         if accept:
             self.startup_script = what
-            self.app.get_dwarf().spawn(widget_android_package.get_package_name(), script=what)
+
+            app_name = widget_android_package.appname
+            package_name = widget_android_package.get_package_name()
+
+            self.app.get_dwarf().spawn(package_name, script=what)
+            self.app.get_dwarf().app_window.update_title("Dwarf - Attached to %s (%s)" % (app_name, package_name))

--- a/ui/widget_android_package.py
+++ b/ui/widget_android_package.py
@@ -21,6 +21,7 @@ class AndroidAppWidget(NotEditableListWidgetItem):
     def __init__(self, application):
         super().__init__(application.name)
 
+        self.appname = application.name
         self.package_name = application.identifier
 
     def get_package_name(self):
@@ -31,6 +32,7 @@ class AndroidPackageWidget(NotEditableListWidgetItem):
     def __init__(self, label, package_name, pid):
         super().__init__(label)
 
+        self.appname = label
         self.package_name = package_name
         self.pid = pid
 


### PR DESCRIPTION
Quick fix to dynamically populate the session window title with the app name + pid or app name + package ID.

Only tested on Mojave and with an iOS device.

See comments -> there is a cleanup where i split on \t to get the app name on iOS, im not sure if the Frida output is similar on Android, i don't have a device with me right now.
