### PR TITLE
multiple changes and improvements

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -260,7 +260,7 @@ function Dwarf() {
         var op = recv('' + Process.getCurrentThreadId(), function (payload) {});
         op.wait();
 
-        var hook_context = getDwarf().hook_contexts[Process.getCurrentThreadId()];
+        const hook_context = that['hook_context'];
 
         if (typeof hook_context !== 'undefined') {
             while (hook_context.api_queue.length === 0) {
@@ -370,7 +370,14 @@ function Dwarf() {
                 _log('[' + Process.getCurrentThreadId() + '] onHook ' + p + ' - dispatching context info');
             }
 
-            this._sendInfos(reason, p, context);
+            this._sendInfos(reason, p, context, hook);
+
+            // dispatch post context setup callbacks
+            if (hook !== null && hook.postContextSetup !== null && typeof hook.postContextSetup === 'function') {
+                hook.postContextSetup.apply({
+                    context: context
+                });
+            }
 
             if (DEBUG) {
                 _log('[' + Process.getCurrentThreadId() + '] onHook ' + p + ' - creating dwarf context');
@@ -398,7 +405,7 @@ function Dwarf() {
         return this.context;
     };
 
-    this._sendInfos = function (reason, p, ctx) {
+    this._sendInfos = function (reason, p, ctx, hook) {
         var tid;
         if (p === null && ctx === null) {
             tid = Process.id;
@@ -421,24 +428,24 @@ function Dwarf() {
             data['context'] = ctx;
             var pc = this.procedure_call_register;
             if (typeof ctx[pc] !== 'undefined') {
-                var symb;
-                try {
-                    symb = DebugSymbol.fromAddress(ctx[pc]);
-                } catch (e) {
-                    _log_err('_sendInfos', e);
-                }
-                if (symb === null || typeof symb === 'undefined') {
-                    symb = {};
+                var symb = null;
+                if (hook.showDetails) {
+                    try {
+                        symb = DebugSymbol.fromAddress(ctx[pc]);
+                    } catch (e) {
+                        _log_err('_sendInfos', e);
+                    }
                 }
 
                 if (DEBUG) {
                     _log('[' + tid + '] sendInfos - preparing native backtrace');
                 }
 
-                bt = { 'bt': api.nativeBacktrace(ctx), 'type': 'native' };
+                if (hook.showDetails) {
+                    data['backtrace'] = { 'bt': api.nativeBacktrace(ctx), 'type': 'native' };
+                }
                 data['ptr'] = p;
                 data['is_java'] = false;
-                data['backtrace'] = bt;
 
                 if (DEBUG) {
                     _log('[' + tid + '] sendInfos - preparing context registers');
@@ -459,7 +466,9 @@ function Dwarf() {
                         'telescope': ts
                     };
                     if (reg === pc) {
-                        newCtx[reg]['symbol'] = symb;
+                        if (symb !== null) {
+                            newCtx[reg]['symbol'] = symb;
+                        }
                         try {
                             var inst = Instruction.parse(val);
                             newCtx[reg]['instruction'] = {
@@ -519,7 +528,9 @@ function Dwarf() {
                     hook.debugSymbol = DebugSymbol.fromAddress(hook.nativePtr);
                     hook.interceptor = DwarfInterceptor.attach(hook.nativePtr, function () {
                         api.deleteHook(hook.nativePtr);
-                    }, true);
+                    }, {
+                        _internal: true
+                    });
                     initialHook.detach();
                 });
             }
@@ -1098,9 +1109,9 @@ function DwarfApi() {
         }
     };
 
-    this.hookNative = function (what, logic) {
+    this.hookNative = function (what, logic, options) {
         if (isDefined(what)) {
-            DwarfInterceptor.attach(what, logic);
+            DwarfInterceptor.attach(what, logic, options);
         }
     };
 
@@ -2046,11 +2057,15 @@ function Emulator() {
         loggedSend('emulator:::clean')
     };
 
-    this.setup = function (tid) {
+    this.setup = function (tid, arch, mode) {
         if (typeof tid !== 'number') {
             tid = Process.getCurrentThreadId();
         }
-        loggedSend('emulator:::setup:::' + tid);
+        var msg = 'emulator:::setup:::' + tid;
+        if (isDefined(arch) && isDefined(mode)) {
+            msg += ':::' + arch + ':::' + mode;
+        }
+        loggedSend(msg)
     };
 
     this.start = function (until) {
@@ -2058,11 +2073,15 @@ function Emulator() {
     };
 
     this.step = function () {
-        loggedSend('emulator:::start:::1')
+        loggedSend('emulator:::step:::1')
     };
 
     this.stepFunction = function () {
-        loggedSend('emulator:::start:::2')
+        loggedSend('emulator:::step:::2')
+    };
+
+    this.stepJump = function () {
+        loggedSend('emulator:::step:::3')
     };
 
     this.stop = function () {
@@ -2087,6 +2106,9 @@ function Hook() {
     this.interceptor = null;
     this.javaOverloads = {};
     this.bytes = [];
+
+    this.postContextSetup = null;
+    this.showDetails = true;
 }
 
 function HookApi(api_funct, args) {
@@ -2524,9 +2546,19 @@ var _log_err = function (tag, err) {
 
 var wrappedInterceptor = Interceptor;
 var InterceptorWrapper = function () {
-    this.attach = function (pt, logic, internal) {
+    const _getOption = function (options, key, def) {
+        var ret = options[key];
+        if (typeof ret !== 'undefined') {
+            return ret;
+        }
+        return def;
+    };
+    this.attach = function (pt, logic, options) {
         try {
-            internal = internal || false;
+            options = options || {};
+            var internal = _getOption(options, '_internal', false);
+            var showDetails = _getOption(options, 'details', true);
+
             var hook;
             var dethumbedPtr;
             if (pt instanceof Hook) {
@@ -2549,6 +2581,7 @@ var InterceptorWrapper = function () {
             }
 
             hook.internalHook = internal;
+            hook.showDetails = showDetails;
 
             // we will send this for range class and avoid showing frida trampolines when dumping ranges
             hook.bytes = getDwarf()._ba2hex(Memory.readByteArray(dethumbedPtr, Process.pointerSize * 2));
@@ -2556,6 +2589,9 @@ var InterceptorWrapper = function () {
             if (typeof logic === 'function') {
                 hook.interceptor = Interceptor.attach(hook.nativePtr, function (args) {
                     this.detach = hook.interceptor.detach;
+                    this.postContextSetup = function (callback) {
+                        hook.postContextSetup = callback;
+                    };
                     var result = hook.logic.call(this, args);
                     if (typeof result === 'undefined' || (typeof result === 'number' && result >= 0)) {
                         getDwarf()._onHook(REASON_HOOK, hook.nativePtr, this.context, hook, null);
@@ -2568,6 +2604,9 @@ var InterceptorWrapper = function () {
 
                         if (typeof logic['onEnter'] !== 'undefined') {
                             this.detach = hook.interceptor.detach;
+                            this.postContextSetup = function (callback) {
+                                hook.postContextSetup = callback;
+                            };
                             result = hook.logic['onEnter'].call(this, args);
                         }
                         if (typeof result === 'undefined' || (typeof result === 'number' && result >= 0)) {
@@ -2577,6 +2616,9 @@ var InterceptorWrapper = function () {
                     onLeave: function (retval) {
                         if (typeof logic['onLeave'] !== 'undefined') {
                             this.detach = hook.interceptor.detach;
+                            this.postContextSetup = function (callback) {
+                                hook.postContextSetup = callback;
+                            };
                             hook.logic['onLeave'].call(this, retval);
                         }
                     }

--- a/ui/app.py
+++ b/ui/app.py
@@ -858,8 +858,7 @@ class AppWindow(QMainWindow):
                 self.java_explorer_panel._set_handle_arg(-1)
                 self.show_main_tab('jvm-debugger')
             else:
-                self.context_panel.set_context(context['ptr'], 0,
-                                               context['context'])
+                self.context_panel.set_context(context['ptr'], 0, context['context'])
 
                 if 'pc' in context['context']:
                     if not 'disassembly' in self._ui_elems or manual:


### PR DESCRIPTION
- inside an hook callback you can now use ``this.postContextSetup(function() {});``
the callback will be dispatched after the backend have the context in place (as standard hooks callbacks are executed before dispatching the data to the backend). This was need to automate the emulator through js api which require backend context in place
- added a third object to Interceptor.attach(ptr, callback, options) which takes an dictonary of options.
unique public option actually available is details true/false. certain hooks bring trouble parsing additional informations such as backtrace and symbols. this collect just the base information needed by the backend
* fix emulator start/setup/step from js api