### PR TITLE
Fixed minor bugs with device length and root check

### DIFF
--- a/lib/adb.py
+++ b/lib/adb.py
@@ -160,8 +160,8 @@ class Adb(QObject):
                 except ValueError:
                     pass
 
-            root_res = self._do_adb_command('shell whoami')
-            if 'root' in root_res:
+            res = self._do_adb_command('shell whoami')
+            if 'root' in res:
                 self._is_root = True
 
             # check status of selinux

--- a/lib/adb.py
+++ b/lib/adb.py
@@ -157,9 +157,12 @@ class Adb(QObject):
                                 if su_res[res_len - 4] == date_res[date_len - 4]: # day
                                     if su_res[res_len - 5] == date_res[date_len - 5]: # month
                                         self._is_root = True
-
                 except ValueError:
                     pass
+
+            root_res = self._do_adb_command('shell whoami')
+            if 'root' in root_res:
+                self._is_root = True
 
             # check status of selinux
             res = self._do_adb_command('shell getenforce')

--- a/ui/widgets/device_bar.py
+++ b/ui/widgets/device_bar.py
@@ -198,7 +198,6 @@ class DevicesUpdateThread(QThread):
     def run(self):
         # get frida devices
         devices = frida.get_device_manager().enumerate_devices()
-
         for device in devices:
             self.onAddDevice.emit({'id': device.id, 'name': device.name, 'type': device.type})
 
@@ -374,7 +373,7 @@ class DeviceBar(QWidget):
 
     def _on_devices_finished(self):
         if self._devices:
-            if len(self._devices) > 1:
+            if len(self._devices) >= 1:
                 self._devices_combobox.clear()
                 self._devices_combobox.setVisible(True)
                 self.update_label.setText('Please select the Device: ')


### PR DESCRIPTION
There was a check for if `len(devices) > 1`. I only had one device, so changing it to `>= 1` worked for me.  

My lineageOS device doesn't have su but is rooted, which I believe fell outside of the original root check conditional coverage. The `adb shell whoami` check fixes it on my end.