### PR TITLE
Update session.py to fix crash on launch.

### DIFF
--- a/dwarf/lib/session/session.py
+++ b/dwarf/lib/session/session.py
@@ -106,17 +106,18 @@ class Session(QObject):
 
     def start(self, args):
         self.dwarf.onScriptDestroyed.connect(self.stop)
+        
+        if not args.device:
+            self.dwarf.device = self.frida_device
+        else:
+            self.dwarf.device = frida.get_device(id=args.device)
+
         if args.any == '':
             self._device_window.onSelectedProcess.connect(self._on_proc_selected)
             self._device_window.onSpawnSelected.connect(self._on_spawn_selected)
             self._device_window.onClosed.connect(self._on_device_dialog_closed)
             self._device_window.show()
         else:
-            if not args.device:
-                self.dwarf.device = self.frida_device
-            else:
-                self.dwarf.device = frida.get_device(id=args.device)
-
             if args.pid > 0:
                 print('* Trying to attach to {0}'.format(args.pid))
                 try:


### PR DESCRIPTION
Dwarf was crashing after platform select when launched without any arguments because when checking for the device id, `self.dwarf.device` would return a 'NoneType'.
I propose we move the logic that checks and retrieves the device id to the start of the session, fixing this crash.