### PR TITLE
Allow having spaces on the path of the project

### DIFF
--- a/dwarf/creator.py
+++ b/dwarf/creator.py
@@ -140,9 +140,9 @@ def main():
     with open(injector, 'w') as f:
         f.write(dwarf_launcher)
 
-    os.system("cd %s && npm install" % path)
+    os.system("cd \"%s\" && npm install" % path)
     if os.name != 'nt':
-        os.system("cd %s && chmod a+x dwarf" % path)
+        os.system("cd \"%s\" && chmod a+x dwarf" % path)
 
     print('')
     print("project create at %s. edit src/agent.ts" % path)


### PR DESCRIPTION
The creator tool didn't handle spaces on the project path