### PR TITLE
Fix frida_remote['tag_name']

### DIFF
--- a/dwarf_debugger/dwarf.py
+++ b/dwarf_debugger/dwarf.py
@@ -195,11 +195,11 @@ def run_dwarf():
         remote_frida = _git.get_frida_version()
         local_frida = frida.__version__
 
-        if remote_frida and local_frida != remote_frida[0]['tag_name']:
-            print('Updating local frida version to ' + remote_frida[0]['tag_name'])
+        if remote_frida and local_frida != remote_frida['tag_name']:
+            print('Updating local frida version to ' + remote_frida['tag_name'])
             try:
                 res = utils.do_shell_command('pip3 install frida --upgrade --user')
-                if 'Successfully installed frida-' + remote_frida[0]['tag_name'] in res:
+                if 'Successfully installed frida-' + remote_frida['tag_name'] in res:
                     _on_restart()
                 elif 'Requirement already up-to-date' in res:
                     if os.path.exists('.git_cache'):


### PR DESCRIPTION
Traceback (most recent call last):
  File "dwarf.py", line 25, in <module>
    run_dwarf()
  File "../Dwarf/dwarf_debugger/dwarf.py", line 198, in run_dwarf
    if remote_frida and local_frida != remote_frida[0]['tag_name']:
KeyError: 0