### PR TITLE
fix: properly check for missing commands

### DIFF
--- a/dwarf_debugger/lib/adb.py
+++ b/dwarf_debugger/lib/adb.py
@@ -424,9 +424,9 @@ class Adb(QObject):
 
         result = self._do_adb_command('shell frida --version')
         if result:
-            if 'frida: not found' in result or 'No such file or directory' in result:
+            if 'not found' in result or 'No such file or directory' in result:
                 result = self._do_adb_command('shell frida-server --version')
-                if result and 'frida-server: not found' in result:
+                if result and 'not found' in result:
                     return None
                 elif result:
                     self._alternate_frida_name = True


### PR DESCRIPTION
On some, or at least on my device, the output for a command that has not been found is different thus the check for frida/-server will always fail until the command actually exists. This is a problem, because the installation in /system did fail for me. See #71. 

Also related to this: #72. Having an option to manually specify the frida-server location would've helped in my case.

```
$ foobar
/system/bin/sh: foobar: inaccessible or not found
```